### PR TITLE
Add Supports For Laravel 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
-          coverage: none
       - name: Remove some dev dependencies
         run: composer remove "ekino/phpstan-banned-code" "nunomaduro/larastan" "phpmd/phpmd" "phpstan/phpstan-deprecation-rules" --dev --no-update
       - name: Get Composer Cache Directory

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,39 +2,41 @@ name: Build
 
 on:
   push:
-    paths-ignore: ['*.md']
+    paths-ignore: ["*.md"]
   pull_request:
-    paths-ignore: [ '*.md' ]
-    branches: [ master ]
+    paths-ignore: ["*.md"]
+    branches: [main]
 
 jobs:
   analysis:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: laravel-varnishable-analysis
-        with:
-          path: ~/.composer
-          key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        env:
+          cache-name: laravel-varnishable-analysis
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            php-${{ matrix.php }}-build-${{ env.cache-name }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
-      - name: Run statuc analysis
+      - name: Run static analysis
         run: composer analyse
   test:
     name: Test (PHP ${{ matrix.php }})
@@ -42,57 +44,64 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [8.0, 8.1, 8.2]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
           coverage: none
       - name: Remove some dev dependencies
-        run: composer remove "ekino/phpstan-banned-code" "nunomaduro/larastan" "phpmd/phpmd" "phpstan/phpstan-deprecation-rules" "sebastian/phpcpd" --dev --no-update
+        run: composer remove "ekino/phpstan-banned-code" "nunomaduro/larastan" "phpmd/phpmd" "phpstan/phpstan-deprecation-rules" --dev --no-update
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: laravel-varnishable-test
         with:
-          path: ~/.composer
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
             php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run the test suite
         run: vendor/bin/phpunit
   test-coverage:
     name: Test (PHP ${{ matrix.php }})
-    needs: [ analysis ]
+    needs: [analysis]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.2 ]
+        php: [8.3]
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: laravel-varnishable-test
-        with:
-          path: ~/.composer
-          key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            php-${{ matrix.php }}-build-${{ env.cache-name }}-
-            php-${{ matrix.php }}-build-
-            php-${{ matrix.php }}-
+      - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, intl, gd, exif, iconv
+          coverage: none
+      - name: Remove some dev dependencies
+        run: composer remove "ekino/phpstan-banned-code" "nunomaduro/larastan" "phpmd/phpmd" "phpstan/phpstan-deprecation-rules" --dev --no-update
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        env:
+          cache-name: laravel-varnishable-test
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            php-${{ matrix.php }}-build-${{ env.cache-name }}-
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Run the Coverage test suite

--- a/composer.json
+++ b/composer.json
@@ -21,22 +21,20 @@
     "source": "https://github.com/richan-fongdasen/laravel-varnishable"
   },
   "require": {
-    "php": "^7.4|^8.0",
+    "php": "^8.0",
     "guzzlehttp/guzzle": "^7.0",
-    "illuminate/database": "^8.0|^9.0|^10.0",
-    "illuminate/support": "^8.0|^9.0|^10.0"
+    "illuminate/database": "^8.0|^9.0|^10.0|^11.0",
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.0"
   },
   "require-dev": {
     "ekino/phpstan-banned-code": "^1.0",
+    "larastan/larastan": "^1.0|^2.0",
     "mockery/mockery": "^1.4",
-    "nunomaduro/larastan": "^1.0|^2.0",
-    "orchestra/database": "^6.0|dev-master",
-    "orchestra/testbench": "^6.0|^7.0|^8.0",
+    "orchestra/testbench": "^6.0|^7.0|^8.0|9.x-dev",
     "phpmd/phpmd": "^2.11",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpstan/phpstan-strict-rules": "^1.0",
-    "phpunit/phpunit": "^9.5",
-    "sebastian/phpcpd": "^6.0"
+    "phpunit/phpunit": "^9.5|^10.0|^11.0"
   },
   "config": {
     "sort-packages": true
@@ -66,8 +64,7 @@
     "analyse": [
       "composer check-syntax",
       "composer phpstan-analysis",
-      "composer phpmd-analysis",
-      "vendor/bin/phpcpd --min-lines=3 --min-tokens=36 src/"
+      "composer phpmd-analysis"
     ],
     "check-syntax": [
       "! find src -type f -name \"*.php\" -exec php -l {} \\; |  grep -v 'No syntax errors'",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - vendor/nunomaduro/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/ekino/phpstan-banned-code/extension.neon

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Laravel Varnishable Test Suite">
       <directory suffix="Tests.php">./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Build](https://github.com/richan-fongdasen/laravel-varnishable/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/richan-fongdasen/laravel-varnishable/actions/workflows/main.yml) 
+[![Build](https://github.com/richan-fongdasen/laravel-varnishable/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/richan-fongdasen/laravel-varnishable/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/richan-fongdasen/laravel-varnishable/branch/master/graph/badge.svg)](https://codecov.io/gh/richan-fongdasen/laravel-varnishable)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/richan-fongdasen/laravel-varnishable/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/richan-fongdasen/laravel-varnishable/?branch=master)
 [![StyleCI Analysis Status](https://github.styleci.io/repos/135787392/shield?branch=master)](https://github.styleci.io/repos/135787392)
@@ -34,7 +34,7 @@ $ composer require richan-fongdasen/laravel-varnishable
 ### Laravel version compatibility
 
 | Laravel version | Varnishable version |
-|:----------------|:--------------------|
+| :-------------- | :------------------ |
 | 5.1.x - 5.4.x   | 0.x                 |
 | 5.5.x - 5.8.x   | 1.0.x - 1.1.x       |
 | 6.x             | 1.2.x               |
@@ -42,6 +42,7 @@ $ composer require richan-fongdasen/laravel-varnishable
 | 8.x             | ^1.4.x              |
 | 9.x             | 2.0.x               |
 | 10.x            | 2.1.x               |
+| 11.x            | 2.2.x               |
 
 > If you are using Laravel version 5.5+ then you can skip registering the service provider in your Laravel application.
 

--- a/tests/Concerns/InvalidateVarnishCacheTests.php
+++ b/tests/Concerns/InvalidateVarnishCacheTests.php
@@ -5,6 +5,7 @@ namespace RichanFongdasen\Varnishable\Tests\Concerns;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Container\Container;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Varnishable\Tests\TestCase;
 use RichanFongdasen\Varnishable\VarnishableService;
 
@@ -36,7 +37,7 @@ class InvalidateVarnishCacheTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -49,7 +50,7 @@ class InvalidateVarnishCacheTests extends TestCase
         $this->response = Container::getInstance()->make(Response::class, []);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_fullban_request_to_flush_the_entire_cache()
     {
         $options = ['headers' => ['X-Ban-Host' => 'localhost:8000']];
@@ -65,7 +66,7 @@ class InvalidateVarnishCacheTests extends TestCase
         $this->service->flush('localhost:8000');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_ban_requests_based_on_the_given_regex_patterns()
     {
         $options1 = ['headers' => [
@@ -96,7 +97,7 @@ class InvalidateVarnishCacheTests extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_send_ban_requests_based_on_the_given_urls()
     {
         $options1 = ['headers' => [
@@ -127,7 +128,7 @@ class InvalidateVarnishCacheTests extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_generate_varnish_url_correctly()
     {
         $actual = $this->invokeMethod($this->service, 'getVarnishUrl', ['localhost']);

--- a/tests/Concerns/ManageEtagHeaderTests.php
+++ b/tests/Concerns/ManageEtagHeaderTests.php
@@ -3,6 +3,7 @@
 namespace RichanFongdasen\Varnishable\Tests\Concerns;
 
 use Illuminate\Http\Response;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Varnishable\Tests\TestCase;
 use RichanFongdasen\Varnishable\VarnishableService;
 
@@ -27,7 +28,7 @@ class ManageEtagHeaderTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -37,7 +38,7 @@ class ManageEtagHeaderTests extends TestCase
         $this->service = app(VarnishableService::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_add_an_etag_header_to_the_current_response_object()
     {
         $content = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
@@ -47,10 +48,10 @@ class ManageEtagHeaderTests extends TestCase
         $this->invokeMethod($this->service, 'addEtagHeader', [$this->response]);
 
         $actual = $this->response->headers->get('etag');
-        $this->assertEquals('"'. md5($content) .'"', $actual);
+        $this->assertEquals('"' . md5($content) . '"', $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_disable_etag_header_at_runtime()
     {
         $this->service->enableEtag();
@@ -59,7 +60,7 @@ class ManageEtagHeaderTests extends TestCase
         $this->assertFalse($this->service->getConfig('use_etag'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_enable_etag_header_at_runtime()
     {
         $this->service->disableEtag();

--- a/tests/Concerns/ManageLastModifiedHeaderTests.php
+++ b/tests/Concerns/ManageLastModifiedHeaderTests.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\Varnishable\Tests\Concerns;
 
 use Carbon\Carbon;
 use Illuminate\Http\Response;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Varnishable\Tests\TestCase;
 use RichanFongdasen\Varnishable\VarnishableService;
 
@@ -28,7 +29,7 @@ class ManageLastModifiedHeaderTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -38,7 +39,7 @@ class ManageLastModifiedHeaderTests extends TestCase
         $this->service = app(VarnishableService::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_add_last_modified_header_to_the_current_response_object()
     {
         $time = new Carbon('2018-07-16 23:00:00');
@@ -49,7 +50,7 @@ class ManageLastModifiedHeaderTests extends TestCase
         $this->assertEquals($time->toRfc7231String(), $this->response->headers->get('Last-Modified'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_disable_last_modified_header_at_runtime()
     {
         $this->service->enableLastModified();
@@ -58,7 +59,7 @@ class ManageLastModifiedHeaderTests extends TestCase
         $this->assertFalse($this->service->getConfig('use_last_modified'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_enable_last_modified_header_at_runtime()
     {
         $this->service->disableLastModified();
@@ -67,7 +68,7 @@ class ManageLastModifiedHeaderTests extends TestCase
         $this->assertTrue($this->service->getConfig('use_last_modified'));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_last_modified_value_correctly()
     {
         $time = new Carbon('2018-07-16 23:00:00');
@@ -80,7 +81,7 @@ class ManageLastModifiedHeaderTests extends TestCase
         $this->assertEquals($time->getTimestamp(), $actual->getTimestamp());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_last_modified_header_with_the_newest_timestamp()
     {
         $times = [

--- a/tests/Concerns/ManipulateHttpResponseTests.php
+++ b/tests/Concerns/ManipulateHttpResponseTests.php
@@ -3,6 +3,7 @@
 namespace RichanFongdasen\Varnishable\Tests\Concerns;
 
 use Illuminate\Http\Response;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Varnishable\Tests\TestCase;
 use RichanFongdasen\Varnishable\VarnishableService;
 use Symfony\Component\HttpFoundation\HeaderBag;
@@ -35,7 +36,7 @@ class ManipulateHttpResponseTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -46,7 +47,7 @@ class ManipulateHttpResponseTests extends TestCase
         $this->service = app(VarnishableService::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_acknowledge_esi_supports()
     {
         $this->headers->set(\Varnishable::getConfig('esi_capability_header'), 'v1.0');
@@ -58,7 +59,7 @@ class ManipulateHttpResponseTests extends TestCase
         $this->assertEquals('v1.0', $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_wont_acknowledge_esi_supports_when_there_was_no_esi_header_specified()
     {
         $this->service->setRequestHeaders($this->headers);
@@ -69,7 +70,7 @@ class ManipulateHttpResponseTests extends TestCase
         $this->assertNull($actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_add_cacheable_header_to_the_current_response_object()
     {
         \Varnishable::setCacheDuration(60);
@@ -82,7 +83,7 @@ class ManipulateHttpResponseTests extends TestCase
         $this->assertEquals('max-age=3600, public', $cacheControl);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_add_uncacheable_header_to_the_current_response_object()
     {
         $this->service->addUncacheableHeader($this->response);
@@ -92,13 +93,13 @@ class ManipulateHttpResponseTests extends TestCase
         $this->assertEquals('1', $uncacheable);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_calculate_total_cache_duration_in_seconds()
     {
         $data = [5, 15, 30, 60];
         $expected = [300, 900, 1800, 3600];
 
-        for ($i=0; $i<count($data); $i++) {
+        for ($i = 0; $i < count($data); $i++) {
             \Varnishable::setCacheDuration($data[$i]);
             $actual = $this->invokeMethod($this->service, 'getCacheDuration');
 
@@ -106,7 +107,7 @@ class ManipulateHttpResponseTests extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_fully_manipulate_http_response_as_expected()
     {
         \Varnishable::setCacheDuration(120);
@@ -127,7 +128,7 @@ class ManipulateHttpResponseTests extends TestCase
         $this->assertEquals('max-age=7200, public', $actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_partially_manipulate_http_response_object()
     {
         $this->headers->set(\Varnishable::getConfig('esi_capability_header'), 'v1.0');
@@ -144,7 +145,7 @@ class ManipulateHttpResponseTests extends TestCase
         $this->assertNull($actual);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_confirm_if_the_current_response_should_not_be_cached()
     {
         $uncacheableResponse = (new Response)->header(\Varnishable::getConfig('uncacheable_header'), '1');

--- a/tests/Middleware/CacheableByVarnishTests.php
+++ b/tests/Middleware/CacheableByVarnishTests.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\Varnishable\Tests\Middleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Varnishable\Middleware\CacheableByVarnish;
 use RichanFongdasen\Varnishable\Tests\TestCase;
 
@@ -21,14 +22,14 @@ class CacheableByVarnishTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->middleware = app(CacheableByVarnish::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_handle_the_incoming_request_and_manipulate_the_response_headers()
     {
         $content = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
@@ -42,7 +43,9 @@ class CacheableByVarnishTests extends TestCase
 
         $this->middleware->handle(
             $request,
-            function (Request $request) use ($response) { return $response; },
+            function (Request $request) use ($response) {
+                return $response;
+            },
             180
         );
 
@@ -56,6 +59,6 @@ class CacheableByVarnishTests extends TestCase
         $this->assertEquals('max-age=10800, public', $actual);
 
         $actual = $response->headers->get('etag');
-        $this->assertEquals('"'. md5($content) .'"', $actual);
+        $this->assertEquals('"' . md5($content) . '"', $actual);
     }
 }

--- a/tests/Middleware/UncacheableByVarnishTests.php
+++ b/tests/Middleware/UncacheableByVarnishTests.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\Varnishable\Tests\Middleware;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Varnishable\Middleware\UncacheableByVarnish;
 use RichanFongdasen\Varnishable\Tests\TestCase;
 
@@ -21,14 +22,14 @@ class UncacheableByVarnishTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->middleware = app(UncacheableByVarnish::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_handle_the_incoming_request_and_manipulate_the_response_headers()
     {
         $request = new Request;
@@ -36,7 +37,9 @@ class UncacheableByVarnishTests extends TestCase
 
         $this->middleware->handle(
             $request,
-            function (Request $request) use ($response) { return $response; }
+            function (Request $request) use ($response) {
+                return $response;
+            }
         );
 
         $actual = $response->headers->get(\Varnishable::getConfig('uncacheable_header'));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,11 +59,10 @@ abstract class TestCase extends BaseTest
     protected function getPackageProviders($app)
     {
         $this->app = $app;
-        
+
         return [
             \Illuminate\Cache\CacheServiceProvider::class,
             \Illuminate\Events\EventServiceProvider::class,
-            \Orchestra\Database\ConsoleServiceProvider::class,
             \RichanFongdasen\Varnishable\ServiceProvider::class,
         ];
     }
@@ -99,7 +98,7 @@ abstract class TestCase extends BaseTest
         $reflection = new \ReflectionClass(get_class($object));
         $property = $reflection->getProperty($propertyName);
         $property->setAccessible(true);
- 
+
         return $property->getValue($object);
     }
 
@@ -120,7 +119,7 @@ abstract class TestCase extends BaseTest
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/VarnishableObserverTests.php
+++ b/tests/VarnishableObserverTests.php
@@ -4,6 +4,7 @@ namespace RichanFongdasen\Varnishable\Tests;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Varnishable\Events\ModelHasUpdated;
 use RichanFongdasen\Varnishable\Tests\Supports\Models\Post;
 use RichanFongdasen\Varnishable\Tests\Supports\Models\User;
@@ -15,14 +16,14 @@ class VarnishableObserverTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
         User::factory(3)->create();
     }
 
-    /** @test */
+    #[Test]
     public function it_fires_model_has_updated_event_on_creating_new_record()
     {
         Event::fake([ModelHasUpdated::class]);
@@ -32,7 +33,7 @@ class VarnishableObserverTests extends TestCase
         Event::assertDispatched(ModelHasUpdated::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_fires_model_has_updated_event_on_updating_record()
     {
         Event::fake([ModelHasUpdated::class]);
@@ -44,7 +45,7 @@ class VarnishableObserverTests extends TestCase
         Event::assertDispatched(ModelHasUpdated::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_fires_model_has_updated_event_on_deleting_record()
     {
         Event::fake([ModelHasUpdated::class]);
@@ -54,7 +55,7 @@ class VarnishableObserverTests extends TestCase
         Event::assertDispatched(ModelHasUpdated::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_fires_model_has_updated_event_on_restoring_deleted_record()
     {
         User::find(2)->delete();
@@ -71,7 +72,7 @@ class VarnishableObserverTests extends TestCase
         User::withTrashed()->find(2)->restore();
     }
 
-    /** @test */
+    #[Test]
     public function it_fires_eloquent_retrieved_event_on_retrieving_record_from_database()
     {
         app('events')->listen('eloquent.retrieved:*', function () {
@@ -86,7 +87,7 @@ class VarnishableObserverTests extends TestCase
         User::find(2);
     }
 
-    /** @test */
+    #[Test]
     public function it_fires_eloquent_wakeup_event_on_unserializing_model_from_cache()
     {
         app('events')->listen('eloquent.wakeup:*', function () {
@@ -104,7 +105,7 @@ class VarnishableObserverTests extends TestCase
         unserialize($serialized);
     }
 
-    /** @test */
+    #[Test]
     public function it_would_set_last_modified_with_the_newest_updated_at_timestamp()
     {
         $expected = User::orderBy('updated_at', 'desc')->first()->updated_at;
@@ -117,7 +118,7 @@ class VarnishableObserverTests extends TestCase
         $this->assertEquals($expected->getTimestamp(), $actual->getTimestamp());
     }
 
-    /** @test */
+    #[Test]
     public function it_cant_set_last_modified_when_there_was_no_updated_at_columns_available()
     {
         User::all(['id', 'name', 'email']);
@@ -127,7 +128,7 @@ class VarnishableObserverTests extends TestCase
         $this->assertNull($actual);
     }
 
-    /** @test */
+    #[Test]
     public function serialized_events_can_be_unserialized_without_any_errors_with_soft_deleted_model()
     {
         $user = User::find(3);
@@ -148,7 +149,7 @@ class VarnishableObserverTests extends TestCase
         $this->assertCount(0, $model->getDirty());
     }
 
-    /** @test */
+    #[Test]
     public function serialized_events_can_be_unserialized_without_any_errors_with_deleted_model()
     {
         Post::factory(3)->create();

--- a/tests/VarnishableServiceTests.php
+++ b/tests/VarnishableServiceTests.php
@@ -3,6 +3,7 @@
 namespace RichanFongdasen\Varnishable\Tests;
 
 use GuzzleHttp\Client;
+use PHPUnit\Framework\Attributes\Test;
 use RichanFongdasen\Varnishable\VarnishableService;
 
 class VarnishableServiceTests extends TestCase
@@ -19,7 +20,7 @@ class VarnishableServiceTests extends TestCase
      *
      * @return void
      */
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -28,7 +29,7 @@ class VarnishableServiceTests extends TestCase
         $this->service = app(VarnishableService::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_all_of_configurations_on_empty_key()
     {
         $configs = $this->service->getConfig();
@@ -38,7 +39,7 @@ class VarnishableServiceTests extends TestCase
         $this->assertEquals('8888', $configs['varnish_port']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_configuration_values_correctly()
     {
         $this->assertEquals(8888, $this->service->getConfig('varnish_port'));
@@ -47,7 +48,7 @@ class VarnishableServiceTests extends TestCase
         $this->assertEquals('X-Varnish-Cacheable', $this->service->getConfig('cacheable_header'));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_guzzle_client_object_as_expected()
     {
         $guzzle = $this->service->getGuzzle();
@@ -55,7 +56,7 @@ class VarnishableServiceTests extends TestCase
         $this->assertInstanceOf(Client::class, $guzzle);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_configuration_values_at_runtime()
     {
         $this->service->setConfig('cache_duration', 600);
@@ -63,7 +64,7 @@ class VarnishableServiceTests extends TestCase
         $this->assertEquals(600, $this->service->getConfig('cache_duration'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_replace_the_guzzle_client_object_with_a_new_one()
     {
         $newGuzzle = new Client(['base_uri' => 'https://laravel.com/', 'timeout' => 10]);


### PR DESCRIPTION
* Add support for Laravel 11
* Add support for PHP 8.3
* Drop support for PHP 7.4
* Update package dependencies
* Update PHP Unit configuration
* Update the test codes from using doc-comment metadata to use PHP 8 attribute
* Update Github actions workflow's configuration
* Update readme